### PR TITLE
Fix for not seeing pause menu

### DIFF
--- a/PlateupPrepGhost.cs
+++ b/PlateupPrepGhost.cs
@@ -31,7 +31,7 @@ namespace PlateupPrepGhost
 
         private void Awake()
         {
-            harmony.PatchAll();
+            harmony.PatchAll(Assembly.GetExecutingAssembly());
         }
     }
 }

--- a/PlateupPrepGhost.cs
+++ b/PlateupPrepGhost.cs
@@ -15,6 +15,8 @@ namespace PlateupPrepGhost
         public static readonly string VERSION = "1.15";
         protected override void Initialise()
         {
+            if (GameObject.FindObjectOfType<PrepGhostPatcher>() != null)
+                return;
             GameObject prepGhostMod = new GameObject("PlateupPrepGhost");
             prepGhostMod.AddComponent<PrepGhostPatcher>();
             GameObject.DontDestroyOnLoad(prepGhostMod);


### PR DESCRIPTION
When joining other peoples party the Initialize will be called (Each time you join someone). This crashes (prevents from opening) the pause menu
By checking this, harmony wont be patched multiple times / wont patch other mods.

Found by StarFluxGames:
https://discord.com/channels/1027159977040826408/1032598210709028956/1054349807998730251